### PR TITLE
Module parent fix

### DIFF
--- a/lib/blobsterix_carrierwave/blobsterix_carrierwave.rb
+++ b/lib/blobsterix_carrierwave/blobsterix_carrierwave.rb
@@ -61,7 +61,7 @@ module Blobsterix
         remote_processor_array = []
         until current_processor.superclass == BlobsterixUploader
           remote_processor_array+=current_processor.processors.map{|method, args, condition|[method, args]}
-          current_processor = current_processor.parent
+          current_processor = current_processor.module_parent
         end
         remote_processor_array
       else

--- a/lib/blobsterix_carrierwave/version.rb
+++ b/lib/blobsterix_carrierwave/version.rb
@@ -1,3 +1,3 @@
 module BlobsterixCarrierwave
-  VERSION = "1.0.13"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Module::parent is incompatible with rails 6.1

https://apidock.com/rails/v6.0.0/Module/parent
https://apidock.com/rails/v6.1.3.1/Module/module_parent

@tnitsche