### PR TITLE
Bump gem and carrierwave version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+= 1.1.1
+  * updated carrierwave
 = 1.0.8
   * added option to pass query string parameters
 = 1.0.7

--- a/blobsterix_carrierwave.gemspec
+++ b/blobsterix_carrierwave.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = BlobsterixCarrierwave::VERSION
 
-  gem.add_dependency "carrierwave", "~> 0.10.0"
+  gem.add_dependency "carrierwave", "~> 1.3.2"
   gem.add_dependency "fog"        , "1.37"
 end

--- a/lib/blobsterix_carrierwave/version.rb
+++ b/lib/blobsterix_carrierwave/version.rb
@@ -1,3 +1,3 @@
 module BlobsterixCarrierwave
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
bump gem version to fix the following security issues associated with carrierwave version 0.10.0

```
Name: carrierwave
Version: 0.10.0
CVE: CVE-2021-21305
GHSA: GHSA-cf3w-g86h-35x4
Criticality: High
URL: https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-cf3w-g86h-35x4
Title: Code Injection vulnerability in CarrierWave::RMagick
Solution: upgrade to '~> 1.3.2', '>= 2.1.1'

Name: carrierwave
Version: 0.10.0
CVE: CVE-2021-21288
GHSA: GHSA-fwcm-636p-68r5
Criticality: Medium
URL: https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-fwcm-636p-68r5
Title: Server-side request forgery in CarrierWave
Solution: upgrade to '~> 1.3.2', '>= 2.1.1' 
```