### PR TITLE
Bump gem and carrierwave version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,5 @@
+= 1.1.1
+  * updated carrierwave
 = 1.0.8
   * added option to pass query string parameters
 = 1.0.7

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,7 @@
 = 1.1.1
   * updated carrierwave
+  BREAKING CHANGES:
+    * in case you used the uploader version patch before you have to now include the patches/carrierwave_1x_... version of the patch.
 = 1.0.8
   * added option to pass query string parameters
 = 1.0.7

--- a/blobsterix_carrierwave.gemspec
+++ b/blobsterix_carrierwave.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = BlobsterixCarrierwave::VERSION
 
-  gem.add_dependency "carrierwave", "~> 0.10.0"
+  gem.add_dependency "carrierwave", "~> 1.3.2"
   gem.add_dependency "fog"        , "1.37"
 end

--- a/blobsterix_carrierwave.gemspec
+++ b/blobsterix_carrierwave.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = BlobsterixCarrierwave::VERSION
 
   gem.add_dependency "carrierwave", "~> 1.3.2"
-  gem.add_dependency "fog"        , "1.37"
+  gem.add_dependency "fog"        , "~> 1.37"
 end

--- a/lib/blobsterix_carrierwave.rb
+++ b/lib/blobsterix_carrierwave.rb
@@ -2,6 +2,7 @@ require "blobsterix_carrierwave/version"
 
 require "carrierwave"
 require "fog"
+require 'carrierwave/storage/fog'
 
 require "blobsterix_carrierwave/blobsterix_carrierwave"
 require "blobsterix_carrierwave/blobsterix_storage"

--- a/lib/blobsterix_carrierwave/patches/carrierwave_1x_uploader_version_name.rb
+++ b/lib/blobsterix_carrierwave/patches/carrierwave_1x_uploader_version_name.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+module CarrierWave
+  module Uploader
+    module ClassMethods
+      def version(name, options = {}, &block)
+        uploader = Class.new(self)
+        const_set("Uploader#{name.to_s.gsub('-', '_')}", uploader) # Set the version-specific class name
+        uploader.version_names = [name.to_s]
+        uploader.versions = {}
+        uploader.processors = []
+
+        uploader.class_eval do
+          define_singleton_method(:enable_processing) do |value = nil|
+            self.enable_processing = value unless value.nil?
+            @enable_processing.nil? ? superclass.enable_processing : @enable_processing
+          end
+
+          define_method(:move_to_cache) do
+            false
+          end
+        end
+
+        uploader.class_eval(&block) if block_given?
+
+        define_method(name) do
+          versions[name.to_sym]
+        end
+
+        current_version = {
+          name.to_sym => {
+            uploader: uploader,
+            options: options
+          }
+        }
+        self.versions = versions.merge(current_version)
+      end
+    end
+  end
+end

--- a/lib/blobsterix_carrierwave/version.rb
+++ b/lib/blobsterix_carrierwave/version.rb
@@ -1,3 +1,3 @@
 module BlobsterixCarrierwave
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
bump gem version to fix the following security issues associated with carrierwave version 0.10.0

```
Name: carrierwave
Version: 0.10.0
CVE: CVE-2021-21305
GHSA: GHSA-cf3w-g86h-35x4
Criticality: High
URL: https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-cf3w-g86h-35x4
Title: Code Injection vulnerability in CarrierWave::RMagick
Solution: upgrade to '~> 1.3.2', '>= 2.1.1'

Name: carrierwave
Version: 0.10.0
CVE: CVE-2021-21288
GHSA: GHSA-fwcm-636p-68r5
Criticality: Medium
URL: https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-fwcm-636p-68r5
Title: Server-side request forgery in CarrierWave
Solution: upgrade to '~> 1.3.2', '>= 2.1.1' 
```

add `require 'carrierwave/storage/fog'` to fix` TypeError: superclass must be a Class (Module given)`